### PR TITLE
Update expected output from git versions greater than 2.7

### DIFF
--- a/tests/git_adapter_test.rb
+++ b/tests/git_adapter_test.rb
@@ -12,7 +12,7 @@ require 'grack/git_adapter'
 class GitAdapterTest < Minitest::Test
   include Grack
 
-  GIT_RECEIVE_RESPONSE = %r{\A001b# service=receive-pack\n0000[0-9a-f]{4}cb067e06bdf6e34d4abebf6cf2de85d65a52c65e refs/heads/master\000\s*report-status delete-refs side-band-64k quiet ofs-delta.*\n0000\z}
+  GIT_RECEIVE_RESPONSE = %r{\A001b# service=receive-pack\n0000[0-9a-f]{4}cb067e06bdf6e34d4abebf6cf2de85d65a52c65e refs/heads/master\000\s*report-status delete-refs side-band-64k quiet (atomic )?ofs-delta.*\n0000\z}
 
   def git_config_set(name, value)
     system(git_path, 'config', '--local', name, value, :chdir => example_repo)


### PR DESCRIPTION
We need a minor update to the expected git output in a test for git versions newer than at least 2.7 from my testing.  The actual functionality the test is testing is unchanged and works as expected.
